### PR TITLE
revert_codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,5 +5,5 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @jordonezlucena @PedroDiez @KlausReifenrath @ksl4dtit
+* @jordonezlucena @PedroDiez
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management



#### What this PR does / why we need it:

To avoid problems in codeowners behaviour until people is fully subscribed to WG

Related to Markus's comments on PR#15 - https://github.com/camaraproject/BlockchainPublicAddress/pull/15
