### PR TITLE
Update Codeowners: Remove Sebastian and Jose Antonio and Add Krzysztof

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,5 +5,5 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @jordonezlucena @PedroDiez @grgpapadopoulos @ksl4dtit
+* @PedroDiez @grgpapadopoulos @ksl4dtit
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,5 +5,5 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @jordonezlucena @PedroDiez @sebKoeller @grgpapadopoulos
+* @jordonezlucena @PedroDiez @grgpapadopoulos @ksl4dtit
 


### PR DESCRIPTION
#### What type of PR is this?

* subproject management


#### What this PR does / why we need it:

Remove Sebastian as no longer participating in the WG
Remove Jose Antonio as not involved in technical track
Add Krzysztof as enabled his subscription
