### PR TITLE
Update of maintainers info

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,6 @@
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 * @PedroDiez @grgpapadopoulos @ksl4dtit
 
+# Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
+/CODEOWNERS @camaraproject/admins
+/MAINTAINERS.MD @camaraproject/admins

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -1,4 +1,4 @@
-| Org                    | Name                                                |
-| -----------------------| ----------------------------------------------------|
-| Telefonica             | Pedro Diez Garcia                                   |
-| Deutsche Telekom       | Georgios Papadopoulos                               |
+| Org                    | Name                     | GitHub                   |
+| -----------------------| -------------------------| -------------------------|
+| Telefonica             | Pedro Diez Garcia        | PedroDiez                |
+| Deutsche Telekom       | Georgios Papadopoulos    | grgpapadopoulos          |


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management



#### What this PR does / why we need it:

Update maintainers with GitHub User. Update codeowners file to make codeowners/maintainers as CAMARA admin
See

- #53 


#### Which issue(s) this PR fixes:

Fixes #53


#### Special notes for reviewers:

Coming from TSC guideline


#### Changelog input

N/A

#### Additional documentation 

N/A
