### PR TITLE
Avoid phoneNumber as query param - Blockchains Retrieval

### DIFF
--- a/code/API_definitions/blockchain-public-address.yaml
+++ b/code/API_definitions/blockchain-public-address.yaml
@@ -47,8 +47,8 @@ tags:
   - name: Blockchain Public Address
     description: API operations to manage Blockchain Public Addresses
 paths:
-  /blockchain-public-addresses:
-    get:
+  /blockchain-public-addresses/retrieve-blockchains:
+    post:
       tags:
         - Blockchain Public Address
       summary: Retrieves Blockchain Public Address associated with a mobile phone number.
@@ -60,8 +60,13 @@ paths:
         - openId:
             - blockchain-public-address:read
       parameters:
-        - $ref: "#/components/parameters/PhoneNumber"
         - $ref: "#/components/parameters/x-correlator"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PhoneNumber"
+        required: true
       responses:
         "200":
           description: OK
@@ -104,6 +109,7 @@ paths:
           $ref: "#/components/responses/Generic503"
         "504":
           $ref: "#/components/responses/Generic504"
+  /blockchain-public-addresses:
     post:
       tags:
         - Blockchain Public Address
@@ -122,6 +128,7 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/BindBlockchainPublicAddressRequest"
+        required: true
       responses:
         "201":
           description: Created
@@ -223,6 +230,15 @@ components:
       schema:
         type: string
   schemas:
+    PhoneNumber:
+      type: object
+      description: Payload to retrieve the Blockchain Public Address(es) associated to a given Phone Number
+      required:
+        - phoneNumber
+      properties:
+        phoneNumber:
+          type: string
+          description: A public identifier addressing a telephone subscription. In mobile networks it corresponds to the MSISDN (Mobile Station International Subscriber Directory Number). In order to be globally unique it has to be formatted in international format, according to E.164 standard, prefixed with '+'.
     BindBlockchainPublicAddressRequest:
       type: object
       description: Payload to request the Bind of the Blockchain Public Address

--- a/code/API_definitions/blockchain-public-address.yaml
+++ b/code/API_definitions/blockchain-public-address.yaml
@@ -268,6 +268,7 @@ components:
               - `ethereum` blockchain would be identified by `evm:1` value (i.e. ethereum mainnet).
               - `polygon` blockchain would be identified by `evm:137` value (i.e. polygon mainnet).
               - `celo` blockchain would be identified by `evm:42220` value (i.e. celo mainnet).
+              - `aleph zero` blockchain would be identified by `evm:41455` value (i.e. aleph zero evm).
             - `bitcoin`: Representing Bitcoin L1 blockchain. No `<sub_id>` concept applies for this L1 Ecosystem
             - `solana`: Representing Solana L1 blockchain. No `<sub_id>` concept applies for this L1 Ecosystem
             - `cardano`: Representing Cardano L1 blockchain. No `<sub_id>` concept applies for this L1 Ecosystem
@@ -319,6 +320,7 @@ components:
               - `ethereum` blockchain would be identified by `evm:1` value (i.e. ethereum mainnet).
               - `polygon` blockchain would be identified by `evm:137` value (i.e. polygon mainnet).
               - `celo` blockchain would be identified by `evm:42220` value (i.e. celo mainnet).
+              - `aleph zero` blockchain would be identified by `evm:41455` value (i.e. aleph zero evm).
             - `bitcoin`: Representing Bitcoin L1 blockchain. No `<sub_id>` concept applies for this L1 Ecosystem
             - `solana`: Representing Solana L1 blockchain. No `<sub_id>` concept applies for this L1 Ecosystem
             - `cardano`: Representing Cardano L1 blockchain. No `<sub_id>` concept applies for this L1 Ecosystem


### PR DESCRIPTION
#### What type of PR is this?

* enhancement/feature


#### What this PR does / why we need it:

Avoid the use of a concept with personal information as query param (phoneNumber)
BlockChain Public Addresses Retrieval refactored to be a POST endpoint

Adding Aleph Zero Network


#### Which issue(s) this PR fixes:

Fixes #51, #59


#### Special notes for reviewers:

N/A


#### Changelog input

```
 Avoid the use of a concept with personal information as query param (phoneNumber)
 Adding Aleph Zero Network

```


#### Additional documentation 

N/A